### PR TITLE
ci: setup the CI env variable to true when testing docker-compose in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+    - name: Prepare docker-compose to be tested in CI
+      run: sed 's/CI:\s.*/CI:\ \"true\"/g' -i docker-compose.yml
     - name: Run compose
       run: docker-compose up --build
   release:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,17 @@ File(rootProject.rootDir.path + "/src/main/yaml").listFiles()
             description = "Launches batch experiments for $capitalizedName"
             maxHeapSize = "${minOf(heap.toInt(), Runtime.getRuntime().availableProcessors() * taskSize)}m"
             File("data").mkdirs()
+            args("--override",
+                """
+                    launcher: {
+                        parameters: {
+                            batch: [ seed, spacing, error ],
+                            showProgress: true,
+                            autoStart: true,
+                            parallelism: $threadCount,
+                        }
+                    }
+                """.trimIndent())
         }
         runAllBatch.dependsOn(batch)
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
         mkdir -p /experiment/charts
         chmod 777 /experiment/charts
   simulation:
+    environment:
+      CI: "false"
     depends_on:
       prepare:
         condition: service_completed_successfully


### PR DESCRIPTION
When a heavy simulation is produced, running the whole batch results in a Github Actions timeout (exceeding 6h).
This PR sets a CI to true inside the `docker-compose.yml` file when tested in CI, preventing the timeout of the workflow but performing a minimal test of the `docker-compose.yml`.