### PR TITLE
build: migrate to develocity plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,14 @@ multiJvm {
     jvmVersionForCompilation.set(usesJvm)
 }
 
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf { it.buildResult.failures.isNotEmpty() }
+    }
+}
+
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(libs.bundles.alchemist.protelis)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,14 +38,6 @@ multiJvm {
     jvmVersionForCompilation.set(usesJvm)
 }
 
-develocity {
-    buildScan {
-        termsOfUseUrl = "https://gradle.com/terms-of-service"
-        termsOfUseAgree = "yes"
-        publishing.onlyIf { it.buildResult.failures.isNotEmpty() }
-    }
-}
-
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(libs.bundles.alchemist.protelis)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,6 @@
 plugins {
-    id("com.gradle.enterprise") version "3.17.1"
+    id("com.gradle.develocity") version "3.17.1"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-}
-
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishOnFailure()
-    }
 }
 
 rootProject.name = "alchemist-experiments-bootstrap"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ develocity {
     buildScan {
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
-        publishing.onlyIf { it.buildResult.failures.isNotEmpty() }
+        uploadInBackground = !System.getenv("CI").toBoolean()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,4 +3,12 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
+develocity {
+    buildScan {
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf { it.buildResult.failures.isNotEmpty() }
+    }
+}
+
 rootProject.name = "alchemist-experiments-bootstrap"


### PR DESCRIPTION
As per https://docs.gradle.com/enterprise/gradle-plugin/legacy/#develocity_migration this PR integrates the develocity plugin replacing the deprecated gradle enterprise plugin